### PR TITLE
Fix Off-by-one Error in Good Suffix Table Usage

### DIFF
--- a/string_algo/apostolico_giancarlo.py
+++ b/string_algo/apostolico_giancarlo.py
@@ -78,7 +78,7 @@ def string_search(P, T):
             elif L[i+1] == -1:   # Matched suffix does not appear anywhere in P
                 suffix_shift = len(P) - F[i+1]
             else:               # Matched suffix appears in P
-                suffix_shift = len(P) - L[i+1]
+                suffix_shift = len(P) - 1 - L[i+1]
             M[k] = k - h
             k += max(char_shift, suffix_shift)
             i = len(P) - 1

--- a/string_algo/boyer_moore.py
+++ b/string_algo/boyer_moore.py
@@ -89,7 +89,7 @@ def string_search(P, T):
             elif L[i+1] == -1:   # Matched suffix does not appear anywhere in P
                 suffix_shift = len(P) - F[i+1]
             else:               # Matched suffix appears in P
-                suffix_shift = len(P) - L[i+1]
+                suffix_shift = len(P) - 1 - L[i+1]
             shift = max(char_shift, suffix_shift)
             previous_k = k if shift >= i+1 else previous_k  # Galil's rule
             k += shift


### PR DESCRIPTION
# Summary 
When calculating the shift from the Good Suffix rule tables, it appeared to be shifting one too many, which was shown at the breaking test in 6db1f15, and I believe this is due to the value being an index rather than a length like in the "full shift table", so it should be taken from `len(P) - 1` rather than `len(P)`. After this change, the test that broke the implementation now passes and no others have failed, so it seems to be correct and thus I've gone ahead and edited the code on the [Boyer-Moore Wikipedia page](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm).